### PR TITLE
Fixed repetitive calling of the message about loading player data and calling the Forward after each item loading out of turn.

### DIFF
--- a/addons/sourcemod/scripting/shop/player_manager.sp
+++ b/addons/sourcemod/scripting/shop/player_manager.sp
@@ -1427,9 +1427,12 @@ public void PlayerManager_GetItemsFromDB(Database owner, DBResultSet hndl, const
 			ToggleItem(client, item_id, Toggle_On, true, true);
 		}
 	}
-	g_bAuthorized[client] = true;
 
-	OnAuthorized(client);
+	if(!g_bAuthorized[client]) 
+	{
+		g_bAuthorized[client] = true;
+		OnAuthorized(client);
+	}
 }
 
 void PlayerManager_ClearPlayer(int client)


### PR DESCRIPTION
If you reload the plugin that registers some items in the shop after loading the core, then messages about loading the player's data will be spammed in the chat, and the `Shop_OnAuthorized` Forward will be called the same number of times.

```css
iLoco‎ : !rcon sm plugins reload shop_test_mm
[Shop] You data of the shop has been loaded! Type !shop to open the shop!
[Shop] You data of the shop has been loaded! Type !shop to open the shop!
[Shop] You data of the shop has been loaded! Type !shop to open the shop!
[Shop] You data of the shop has been loaded! Type !shop to open the shop!
[Shop] You data of the shop has been loaded! Type !shop to open the shop!
[Shop] You data of the shop has been loaded! Type !shop to open the shop!
[Shop] You data of the shop has been loaded! Type !shop to open the shop!
[Shop] You data of the shop has been loaded! Type !shop to open the shop!
[Shop] You data of the shop has been loaded! Type !shop to open the shop!
[Shop] You data of the shop has been loaded! Type !shop to open the shop!
[Shop] You data of the shop has been loaded! Type !shop to open the shop!
```