### PR TITLE
Update item_manager.sp

### DIFF
--- a/addons/sourcemod/scripting/shop/item_manager.sp
+++ b/addons/sourcemod/scripting/shop/item_manager.sp
@@ -1384,7 +1384,7 @@ bool ItemManager_FillCategories(Menu menu, int source_client, ShopMenu shop_menu
 			{
 				g_hSortArray.GetString(i, category, sizeof(category));
 				index = hCategoriesArray.FindString(category);
-				if(index != -1 && index != x)
+				if(index != -1 && index != x && x < hCategoriesArray.Length)
 				{
 					hCategoriesArray.SwapAt(index, x);
 				}


### PR DESCRIPTION
If you specify more than 8-10 categories in the sorting file "shop_sort.txt", then the plugin, roughly speaking, stops working.
Every time you click "Buy" or "Inventory" the following error occurs:
```
[SM] Exception reported: Invalid index 8 (count: 8) // Here the number is different: 8, 9 or 10
[SM] Blaming: shop.smx
[SM] Call stack trace:
[SM]   [0] ArrayList.SwapAt
[SM]   [1] Line 1389, shop\item_manager.sp::ItemManager_FillCategories
[SM]   [2] Line 564, D:\sourcemod-1.11.0-git6913-linux\addons\sourcemod\scripting\shop.sp::ShowInventory
[SM]   [3] Line 536, D:\sourcemod-1.11.0-git6913-linux\addons\sourcemod\scripting\shop.sp::MainMenu_Handler
```
After changing line 1387 to 
`if(index != -1 && index != x && x < hCategoriesArray.Length)`
the problem no longer occurred.