### PR TITLE
fixed display of a hidden item in the inventory

### DIFF
--- a/addons/sourcemod/scripting/shop/item_manager.sp
+++ b/addons/sourcemod/scripting/shop/item_manager.sp
@@ -1604,7 +1604,7 @@ bool ItemManager_FillItemsOfCategory(Menu menu, int client, int source_client, i
 
 		do
 		{
-			if((shop_menu != Menu_Inventory || shop_menu != Menu_ItemTransfer) && !showAll && kv.GetNum("hide", 0))
+			if((shop_menu != Menu_Inventory && shop_menu != Menu_ItemTransfer) && !showAll && kv.GetNum("hide", 0))
 			{
 				continue;
 			}


### PR DESCRIPTION
If you give an item to a player who has a `"hide" "1"`, then it is not displayed in the inventory

To fix it, you need to change the logical operator `||` to `&&`