### PR TITLE
Ability to pass duration or count in Shop_GiveClientItem

### DIFF
--- a/addons/sourcemod/scripting/include/shop/players.inc
+++ b/addons/sourcemod/scripting/include/shop/players.inc
@@ -432,7 +432,7 @@ native bool Shop_RemoveClientItem(int client, ItemId item_id, int count = 0);
  *
  *	@return	True on success, false otherwise.
  */
-native bool Shop_GiveClientItem(int client, ItemId item_id, int value = 0); //comment delete after check. PlayerManager_GiveClientItem accepts just 2 parameters now, I added third. value=0 means that the native is called with 2 parameters only
+native bool Shop_GiveClientItem(int client, ItemId item_id, int value = 0);
 
 /**
  *	Get's count of an item a player has.

--- a/addons/sourcemod/scripting/include/shop/players.inc
+++ b/addons/sourcemod/scripting/include/shop/players.inc
@@ -426,13 +426,13 @@ native bool Shop_RemoveClientItem(int client, ItemId item_id, int count = 0);
  *
  *	@param client				Client index.
  *	@param item_id				The item id.
- *	@param value				Count if the item is finite and duration if the item is togglable or non-togglable.
+ *	@param value				Count if the item is finite and duration if the item is togglable or non-togglable, -1 eternal
  *  @error                      Invalid player index.
  *	@error						Invalid ItemId.
  *
  *	@return	True on success, false otherwise.
  */
-native bool Shop_GiveClientItem(int client, ItemId item_id, int value = 1);
+native bool Shop_GiveClientItem(int client, ItemId item_id, int value = 0); //comment delete after check. PlayerManager_GiveClientItem accepts just 2 parameters now, I added third. value=0 means that the native is called with 2 parameters only
 
 /**
  *	Get's count of an item a player has.

--- a/addons/sourcemod/scripting/shop.sp
+++ b/addons/sourcemod/scripting/shop.sp
@@ -1652,15 +1652,15 @@ bool RemoveItemEx(int client, const char[] sItemId, int count = 1)
 	return PlayerManager_RemoveItemEx(client, sItemId, count);
 }
 
-bool GiveItem(int client, int item_id)
+bool GiveItem(int client, int item_id, int value = 0)
 {
 	char sItemId[16];
 	IntToString(item_id, sItemId, sizeof(sItemId));
 	
-	return GiveItemEx(client, sItemId);
+	return GiveItemEx(client, sItemId, value);
 }
 
-bool GiveItemEx(int client, const char[] sItemId)
+bool GiveItemEx(int client, const char[] sItemId, int value = 0)
 {
 	int category_id, price, sell_price, count, duration;
 	ItemType type;
@@ -1669,6 +1669,14 @@ bool GiveItemEx(int client, const char[] sItemId)
 	if (!ItemManager_GetItemInfoEx(sItemId, item, sizeof(item), category_id, price, sell_price, count, duration, type))
 	{
 		return false;
+	}
+	
+	if (value != 0) // if value sent from Native Shop_GiveClientItem, we use it as duration or count instead of defaults from items settings
+	{
+		if (type == Item_Finite)
+			count = value;
+		else
+			duration = value;
 	}
 
 	switch (type)

--- a/addons/sourcemod/scripting/shop.sp
+++ b/addons/sourcemod/scripting/shop.sp
@@ -1674,9 +1674,13 @@ bool GiveItemEx(int client, const char[] sItemId, int value = 0)
 	if (value != 0)
 	{
 		if (type == Item_Finite)
+		{
 			count = value;
+		}
 		else
+		{
 			duration = value;
+		}
 	}
 
 	switch (type)

--- a/addons/sourcemod/scripting/shop.sp
+++ b/addons/sourcemod/scripting/shop.sp
@@ -1671,7 +1671,7 @@ bool GiveItemEx(int client, const char[] sItemId, int value = 0)
 		return false;
 	}
 	
-	if (value != 0) // if value sent from Native Shop_GiveClientItem, we use it as duration or count instead of defaults from items settings
+	if (value != 0)
 	{
 		if (type == Item_Finite)
 			count = value;

--- a/addons/sourcemod/scripting/shop/player_manager.sp
+++ b/addons/sourcemod/scripting/shop/player_manager.sp
@@ -145,7 +145,9 @@ public int PlayerManager_GiveClientItem(Handle plugin, int numParams)
 	int item_id = GetNativeCell(2);
 	int value = 0;
 	if (numParams == 3)
+	{
 		value = GetNativeCell(3);
+	}
 	
 	return GiveItem(client, item_id, value);
 }

--- a/addons/sourcemod/scripting/shop/player_manager.sp
+++ b/addons/sourcemod/scripting/shop/player_manager.sp
@@ -147,7 +147,7 @@ public int PlayerManager_GiveClientItem(Handle plugin, int numParams)
 	if (numParams == 3)
 		value = GetNativeCell(3);
 	
-	return GiveItem(client, item_id, value); // if native Shop_GiveClientItem called with 3 parameters, we read value and pass it to GiveItems. Otherwise pass 0
+	return GiveItem(client, item_id, value);
 }
 
 public int PlayerManager_BuyClientItem(Handle plugin, int numParams)

--- a/addons/sourcemod/scripting/shop/player_manager.sp
+++ b/addons/sourcemod/scripting/shop/player_manager.sp
@@ -143,8 +143,11 @@ public int PlayerManager_GiveClientItem(Handle plugin, int numParams)
 	}
 	
 	int item_id = GetNativeCell(2);
+	int value = 0;
+	if (numParams == 3)
+		value = GetNativeCell(3);
 	
-	return GiveItem(client, item_id);
+	return GiveItem(client, item_id, value); // if native Shop_GiveClientItem called with 3 parameters, we read value and pass it to GiveItems. Otherwise pass 0
 }
 
 public int PlayerManager_BuyClientItem(Handle plugin, int numParams)


### PR DESCRIPTION
players.inc
PlayerManager_GiveClientItem accepts just 2 parameters now, I added a third. value=0 means that the native is called with 2 parameters only

player_manager.sp
// if native Shop_GiveClientItem is called with 3 parameters, we read the value and pass it to GiveItems. Otherwise, pass 0

Shop.sp GiveItem()
//If the value is sent from Native Shop_GiveClientItem, we use it as duration or count instead of defaults from items settings